### PR TITLE
Update from previous bugfix for HTTPS queries

### DIFF
--- a/src/it/unimi/di/law/bubing/util/FetchData.java
+++ b/src/it/unimi/di/law/bubing/util/FetchData.java
@@ -320,7 +320,7 @@ public class FetchData implements URIResponse, Closeable {
 				final String scheme = uri.getScheme();
 				final int port = uri.getPort() == -1 ? (scheme.equals("https") ? 443 : 80) : uri.getPort();
  				final HttpHost httpHost = visitState != null ? 
-					new HttpHost(InetAddress.getByAddress(visitState.workbenchEntry.ipAddress).getHostAddress(), uri.getHost(), port, scheme) :
+					new HttpHost(InetAddress.getByAddress(visitState.workbenchEntry.ipAddress), uri.getHost(), port, scheme) :
  					new HttpHost(uri.getHost(), port, scheme);
  				httpClient.execute(httpHost, httpGet, new ResponseHandler<Void>() {
 

--- a/src/it/unimi/di/law/bubing/util/FetchData.java
+++ b/src/it/unimi/di/law/bubing/util/FetchData.java
@@ -320,7 +320,7 @@ public class FetchData implements URIResponse, Closeable {
 				final String scheme = uri.getScheme();
 				final int port = uri.getPort() == -1 ? (scheme.equals("https") ? 443 : 80) : uri.getPort();
  				final HttpHost httpHost = visitState != null ? 
-					new HttpHost(InetAddress.getByAddress(visitState.workbenchEntry.ipAddress).getHostAddress(), port, scheme) :
+					new HttpHost(InetAddress.getByAddress(visitState.workbenchEntry.ipAddress).getHostAddress(), uri.getHost(), port, scheme) :
  					new HttpHost(uri.getHost(), port, scheme);
  				httpClient.execute(httpHost, httpGet, new ResponseHandler<Void>() {
 


### PR DESCRIPTION
Previous bugfix ensured that HTTPS queries were actually made on HTTPS. This new commit adds the correct HOSTNAME to the query (previous fix only ensured the HTTPS). To summarize,

- initial version from upstream was just creating a HttpHost() with the IP Adress,

- first bugfix created the HttpHost with address, port and https scheme, 

- this bugfix adds the actual host, which removes problem on IPs with multiple virtualhosts (which is a very common use case). 