### PR TITLE
Support wget URI format

### DIFF
--- a/src/it/unimi/di/law/warc/records/AbstractWarcRecord.java
+++ b/src/it/unimi/di/law/warc/records/AbstractWarcRecord.java
@@ -161,6 +161,11 @@ public abstract class AbstractWarcRecord extends AbstractHttpMessage implements 
 	public URI getWarcTargetURI() {
 		final Header header = WarcHeader.getFirstHeader(this.warcHeaders, WarcHeader.Name.WARC_TARGET_URI);
 		if (header == null) throw new IllegalStateException(WarcHeader.Name.WARC_TARGET_URI + " header not present");
+		String value = header.getValue();
+		if(value.startsWith("<") && value.endsWith(">")){
+			// Handle wget-specific URI format
+			value = value.substring(1, value.length() - 1);
+		}
 		if (! USE_BURL) return URI.create(header.getValue());
 		final URI result = BURL.parse(header.getValue());
 		if (result == null) throw new IllegalArgumentException("BURL.parse() found an unfixable syntax error in URL " + header.getValue());


### PR DESCRIPTION
Wget internally [represents URIs in the `<URI>` format](https://gitlab.com/gnuwget/wget2/blob/master/libwget/http_parse.c#L246). 
As a side effect,`<` and `>` symbols are also prepended/appended into the **WARC-Target-URI** header of records generated via wget, as you can verify by executing the following 2 lines:

```
wget "https://www.example.com/" --warc-file="example-homepage" --no-warc-compression --no-verbose
grep WARC-Target-URI example-homepage.warc
```
This commits adds the ability to read wget-generated WARC files without incurring in malformed URI exceptions.